### PR TITLE
Add support for 'proxying' data URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ There are however, some crucial changes, and improvements:
 
 - Support for proxying fonts, stylesheets, and URLs in stylesheets
 - Support for protocol-relative URLs / URLs without a scheme
+- Support for redirecting data URIs
 - Higher default timeout
 - Sentry for crash reporting, and aggregation
 - End-to-end health check endpoint (`/health`)

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -207,6 +207,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	mlog.Debugm("signed client url", mlog.Map{"url": sURL})
 
+	// Handle data URI by redirecting to it
+	if strings.HasPrefix(sURL, "data:") {
+		http.Redirect(w, req, sURL, http.StatusMovedPermanently)
+	}
+
 	u, err := url.Parse(sURL)
 
 	if u.Scheme == "" {

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -130,6 +130,24 @@ func TestValidFontURLs(t *testing.T) {
 	}
 }
 
+func TestDataURIs(t *testing.T) {
+	t.Parallel()
+
+	testURIs := []string{
+		"data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7",
+		"data:text/css,html,body{margin:0;padding:0}",
+	}
+
+	for _, testURI := range testURIs {
+		record, err := makeTestReq(testURI, 301)
+		assert.Nil(t, err)
+
+		if assert.Nil(t, err) {
+			assert.Contains(t, record.Body.String(), "data:", "Expected data URIs to be redirected")
+		}
+	}
+}
+
 func TestProtocolRelativeURL(t *testing.T) {
 	t.Parallel()
 	testURL := "//httpbin.org/get"


### PR DESCRIPTION
```
Add support for 'proxying' data URIs

If the target URL is a data URI (e.g. base64 encoded image),
we will simply redirect to it rather than to attempt to proxy it.
```

This is currently an issue on production (the JavaScript `camo`) as well. Unlike the `camo` running on production however, our latest version of `go-camo` doesn't fail or crash miserably. 

Nevertheless, this PR adds support for them. Ideally, the URLs we pass to `go-camo` should not be data URIs, but it can be argued that it is far easier to allow for greater permissiveness on the side of the proxy than to update our link extractor.
