### PR TITLE
Add `url-tool` to the `goreleaser` build pipeline

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,30 @@ builds:
       - windows
     goarch:
       - amd64
+  - main: ./cmd/url-tool/
+    binary: go-camo-url-tool
+    flags: -tags netgo
+    ldflags: -s -w -X main.ServerVersion={{.Commit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
 dockers:
   - image: arachnysdocker/go-camo
+    dockerfile: Dockerfile
     latest: true
+    binary: go-camo
+    goos: linux
+    goarch: amd64
+    goarm: ''
+  - image: arachnysdocker/go-camo-url-tool
+    dockerfile: Dockerfile.url-tool
+    latest: true
+    binary: go-camo-url-tool
+    goos: linux
+    goarch: amd64
+    goarm: ''

--- a/Dockerfile.url-tool
+++ b/Dockerfile.url-tool
@@ -1,0 +1,14 @@
+FROM alpine:3.6
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://www.github.com/arachnys/go-camo" \
+      org.label-schema.docker.cmd="docker run --rm -p 8080:8080 arachnysdocker/go-camo-url-tool -k <hmac key> (encode|decode) <url>" \
+      maintainer="Arachnys <techteam@arachnys.com>"
+
+RUN apk add --no-cache ca-certificates
+
+COPY go-camo-url-tool /
+ENTRYPOINT ["/go-camo-url-tool"]

--- a/README.md
+++ b/README.md
@@ -133,11 +133,16 @@ Extract, and copy files to desired locations.
 Alternatively, run it in Docker using:
 
 ```
-docker run -it --rm -p 8080:8080 arachnysdocker/go-camo:<tag>
+# Server
+docker run -t --rm -p 8080:8080 arachnysdocker/go-camo:<tag> -k <hmac key>
+
+# URL tool
+docker run -t --rm arachnysdocker/go-camo-url-tool:<tag> -k <hmac key>
 ```
 
 Set `<tag>` to a version in the [releases][13] or set it to `latest`.
 For stability, we do not recommend using `latest` as there may be breaking changes.
+Use a [tagged release][21].
 
 ## Building
 
@@ -379,3 +384,4 @@ file for details.
 [18]: https://github.com/arachnys/go-camo/
 [19]: https://www.docker.com/
 [20]: https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html
+[21]: https://github.com/arachnys/go-camo/releases


### PR DESCRIPTION
This commit will allow future releases of `go-camo` to include
URL tool binaries for various platforms, and a Docker image.

See: https://hub.docker.com/r/arachnysdocker/go-camo-url-tool/