### PR TITLE
Fix TTFs returning bad request error

### DIFF
--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -25,15 +25,6 @@ import (
 	"github.com/cactus/mlog"
 )
 
-var acceptedContentTypes = []string{
-	"application/font-woff",
-	"application/vnd.ms-fontobject",
-	"application/x-font",
-	"image/",
-	"text/css",
-}
-var defaultAcceptHeaders = "image/*, text/*, application/*"
-
 // Config holds configuration data used when creating a Proxy with New.
 type Config struct {
 	// HMACKey is a byte slice to be used as the hmac key

--- a/pkg/camo/vars.go
+++ b/pkg/camo/vars.go
@@ -8,6 +8,17 @@ import (
 	"regexp"
 )
 
+var acceptedContentTypes = []string{
+	"application/font-woff",
+	"application/vnd.ms-fontobject",
+	"application/x-font",
+	"font/",
+	"image/",
+	"text/css",
+}
+
+var defaultAcceptHeaders = "image/*, font/*, text/*, application/*"
+
 // ValidReqHeaders are http request headers that are acceptable to pass from
 // the client to the remote server. Only those present and true, are forwarded.
 // Empty implies no filtering.


### PR DESCRIPTION
Proxied URLs from Google fonts CDN are failing with error 400.
That is because the content-type is `font/ttf` which prior to this
commit, was not supported.