### PR TITLE
Gracefully shutdown HTTP(S) server on termination signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There are however, some crucial changes, and improvements:
 - End-to-end health check endpoint (`/health`)
 - Go's `dep` (and vanilla tooling) is used instead of `gb` for dependency management
 - `goreleaser` is used instead of `gb`, and the `Makefile` for building binaries
-- Support for [termination signals][20]
+- Support for graceful shutdown via [termination signals][20]
 - Support for [Docker][19] (`docker pull arachnysdocker/go-camo`)
 
 ---


### PR DESCRIPTION
Previously, a synchronous signal would be converted into a run-time
panic. 359da2d changed the default signal behaviour, but it did not
gracefully shutdown the server, i.e. wait for active connections
to be drained.