### PR TITLE
Support for proxying bad SSL/TLS URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ There are however, some crucial changes, and improvements:
 - Support for proxying fonts, stylesheets, and URLs in stylesheets
 - Support for protocol-relative URLs / URLs without a scheme
 - Support for proxying data URIs
+- Support for proxying bad SSL/TLS URIs
 - Higher default timeout
 - Sentry for crash reporting, and aggregation
 - End-to-end health check endpoint (`/health`)

--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -79,7 +79,7 @@ func main() {
 				os.Exit(0)
 			}
 		}
-		os.Exit(1)
+		mlog.Fatal(err)
 	}
 
 	if len(opts.Version) > 0 {

--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -63,6 +63,7 @@ func main() {
 		MaxRedirects        int           `long:"max-redirects" default:"3" description:"Maximum number of redirects to follow"`
 		DisableKeepAlivesFE bool          `long:"no-fk" description:"Disable frontend http keep-alive support"`
 		DisableKeepAlivesBE bool          `long:"no-bk" description:"Disable backend http keep-alive support"`
+		SkipTLSVerify       bool          `long:"skip-tls-verify" description:"Skip TLS verification of proxied resources"`
 		BindAddress         string        `long:"listen" default:"0.0.0.0:8080" description:"Address:Port to bind to for HTTP"`
 		BindAddressSSL      string        `long:"ssl-listen" description:"Address:Port to bind to for HTTPS/SSL/TLS"`
 		SSLKey              string        `long:"ssl-key" description:"ssl private key (key.pem) path"`
@@ -125,6 +126,9 @@ func main() {
 	// set keepalive options
 	config.DisableKeepAlivesBE = opts.DisableKeepAlivesBE
 	config.DisableKeepAlivesFE = opts.DisableKeepAlivesFE
+
+	// set tls options
+	config.SkipTLSVerify = opts.SkipTLSVerify
 
 	if opts.AllowList != "" {
 		b, err := ioutil.ReadFile(opts.AllowList)

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -9,6 +9,7 @@ package camo
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"io"
@@ -45,6 +46,8 @@ type Config struct {
 	// Keepalive enable/disable
 	DisableKeepAlivesFE bool
 	DisableKeepAlivesBE bool
+	// Skip verification of a server's certificate chain, and host name
+	SkipTLSVerify bool
 }
 
 // ProxyMetrics interface for Proxy to use for stats/metrics.
@@ -461,6 +464,7 @@ func New(pc Config) (*Proxy, error) {
 			Timeout:   3 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).Dial,
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: pc.SkipTLSVerify},
 		TLSHandshakeTimeout: 3 * time.Second,
 		MaxIdleConnsPerHost: 8,
 		DisableKeepAlives:   pc.DisableKeepAlivesBE,

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -162,6 +162,37 @@ func TestProtocolRelativeURL(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestBadSSL(t *testing.T) {
+	t.Parallel()
+
+	testURLs := []string{
+		"https://expired.badssl.com/style.css",
+		"https://self-signed.badssl.com/style.css",
+	}
+
+	for _, testURL := range testURLs {
+		// With TLS verify
+		camoConfig.SkipTLSVerify = false
+
+		req, err := makeReq(testURL)
+		assert.Nil(t, err)
+
+		_, err = processRequest(req, 404, camoConfig)
+		assert.Nil(t, err)
+	}
+
+	for _, testURL := range testURLs {
+		// Without TLS verify
+		camoConfig.SkipTLSVerify = true
+
+		req, err := makeReq(testURL)
+		assert.Nil(t, err)
+
+		_, err = processRequest(req, 200, camoConfig)
+		assert.Nil(t, err)
+	}
+}
+
 func TestGoogleChartURL(t *testing.T) {
 	t.Parallel()
 	testURL := "http://chart.apis.google.com/chart?chs=920x200&chxl=0:%7C2010-08-13%7C2010-09-12%7C2010-10-12%7C2010-11-11%7C1:%7C0%7C0%7C0%7C0%7C0%7C0&chm=B,EBF5FB,0,0,0&chco=008Cd6&chls=3,1,0&chg=8.3,20,1,4&chd=s:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&chxt=x,y&cht=lc"


### PR DESCRIPTION
    Add support for proxying URIs with bad SSL / TLS

    `go-camo` might be given a HTTPS URI to proxy, but the resource
    may not have a valid SSL / TLS certificate, thereby resulting
    in a fetch error. This commit allows TLS verification to be disabled
    so that we can proxy assets that are hosted on a server with a
    bad certificate. To disable, launch with `--skip-tls-verify`.

    Log flags parsing errors

    Previously, it would just exit without any helpful message.
    Logging the error will ease debugging, especially if the field tags
    are invalid.