### PR TITLE
Build `go-camo` with a race detector

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 builds:
   - main: ./cmd/go-camo/
     binary: go-camo
-    flags: -tags netgo
+    flags: -race -tags netgo
     ldflags: -s -w -X main.ServerVersion={{.Commit}}
     env:
       - CGO_ENABLED=0
@@ -13,7 +13,7 @@ builds:
       - amd64
   - main: ./cmd/url-tool/
     binary: go-camo-url-tool
-    flags: -tags netgo
+    flags: -race -tags netgo
     ldflags: -s -w -X main.ServerVersion={{.Commit}}
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
Potentially controversial, but by running a production binary
with the race detector built-in, we are more likely to test
every code path possible, and hence, find data races if there
are any.