### PR TITLE
Fix `runtime error: index out of range` caused by invalid data URI

### DIFF
--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -179,6 +179,10 @@ func parseDataURI(dataURI string) ([]byte, string, error) {
 	}
 
 	group := re.FindStringSubmatch(dataURI)
+	if len(group) < 3 {
+		return nil, "", errors.New("failed to match content-type, and raw data")
+	}
+
 	contentType := group[1]
 	rawData := group[2]
 

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -147,6 +147,7 @@ func TestDataURIs(t *testing.T) {
 		"data:,Hello%2C%20World!",
 		"data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D",
 		"data:text/html,<script>alert('hi');</script>",
+		"data:image/gif;base64,",
 	}
 
 	for _, testURI := range testUnacceptableURIs {


### PR DESCRIPTION
Prevent panic from occurring by checking the group, and returning
an error instead.